### PR TITLE
Feature ignore merge commits

### DIFF
--- a/pistis.go
+++ b/pistis.go
@@ -38,9 +38,10 @@ import (
 )
 
 var (
-	keyring   string
-	directory string
-	logger    *slog.Logger
+	keyring            string
+	directory          string
+	logger             *slog.Logger
+	featureIgnoreMerge bool
 )
 
 func main() {
@@ -48,6 +49,7 @@ func main() {
 	var keyringFile string
 	var logLevelStr string
 
+	flag.BoolVar(&featureIgnoreMerge, "ignore-merge", false, "Do not try to validate merge commits")
 	flag.StringVar(&directory, "repository", ".", "Path to the Git repository")
 	flag.StringVar(&gitlab, "gitlab", "", "URL to a GitLab instance for building the PGP keyring")
 	flag.StringVar(&keyringFile, "keyring", "", "Alternatively, path to file containing an existing armored keyring")
@@ -155,12 +157,16 @@ func logic() {
 	head := ref.Hash()
 	Info("Head is at %s", head)
 
-	history, err := repository.Log(&git.LogOptions{From: ref.Hash()})
+	history, err := repository.Log(&git.LogOptions{From: ref.Hash(), Order: git.LogOrderBSF})
 	handleError("Reading history", err)
 
 	var previousTree *object.Tree
 
 	err = history.ForEach(func(commit *object.Commit) error {
+		if featureIgnoreMerge && len(commit.ParentHashes) > 1 {
+			Debug("Ignoring merge commit %s (%d) parents: %s", commit.Hash.String()[0:9], commit.NumParents(), commit.ParentHashes)
+			return nil
+		}
 		hash := commit.Hash
 
 		if contains(exclusions, hash.String()) {
@@ -171,6 +177,11 @@ func logic() {
 		Info("Reading commit %s", hash)
 
 		pgpObj, verifyErr := commit.Verify(keyring)
+		Debug("Author %s", commit.Author)
+		Debug("Committer %s", commit.Committer)
+		Debug("Signature %s", commit.PGPSignature)
+		Debug("pgpObj %s %v", pgpObj, pgpObj)
+
 		handleError("Verifying commit", verifyErr)
 		cFp := hex.EncodeToString(pgpObj.PrimaryKey.Fingerprint[:])
 

--- a/pistis.go
+++ b/pistis.go
@@ -180,7 +180,6 @@ func logic() {
 		Debug("Author %s", commit.Author)
 		Debug("Committer %s", commit.Committer)
 		Debug("Signature %s", commit.PGPSignature)
-		Debug("pgpObj %s %v", pgpObj, pgpObj)
 
 		handleError("Verifying commit", verifyErr)
 		cFp := hex.EncodeToString(pgpObj.PrimaryKey.Fingerprint[:])

--- a/utils.go
+++ b/utils.go
@@ -45,6 +45,10 @@ func Error(format string, args ...any) {
 	logger.Error(fmt.Sprintf(format, args...))
 }
 
+func Debug(format string, args ...any) {
+	logger.Debug(fmt.Sprintf(format, args...))
+}
+
 func Info(format string, args ...any) {
 	logger.Info(fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
Add -ignore-merge command flag

This flag can be used to ignore merge commits as they are not signed
by gitlab.

Even if we could do automatic signing it would defeat the proposal of
pistis, as we want to use signatures as a notarisation device.

For this to be effective we need to change the order in which we parse
the tree to BFS with git.LogOrderBSF.

That way we ensure that we validate the content of the git merge
before proceeding further down history. And it is this content that
will be signed.

https://en.wikipedia.org/wiki/Breadth-first_search
