### PR TITLE
Add systemd examples

### DIFF
--- a/examples/systemd/pistis-stage.path
+++ b/examples/systemd/pistis-stage.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Git repository monitor
+
+[Path]
+PathChanged=/srv/git-stage/.git/refs/heads/main
+TriggerLimitBurst=50
+
+[Install]
+WantedBy=paths.target

--- a/examples/systemd/pistis-stage.service
+++ b/examples/systemd/pistis-stage.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Git repository validation and synchronization
+
+[Service]
+Type=oneshot
+ExecStart=pistis -gitlab https://gitlab.example.com -repository /srv/git-stage
+ExecStartPost=rsync -av /srv/git-stage/ /srv/git-validated


### PR DESCRIPTION
Add path and service unit examples showing how to use pistis to validate Git repositories before deploying their content.