### PR TITLE
Read usernames from GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Ideally, this should be a clean key ring. If run under a user account already ha
 #### Using GitLab
 
 Alternatively to specifying an existing keyring file, a keyring can be built from PGP keys associated with users on a GitLab server.
-For this, specify `--gitlab` instead of `--keyring`, and maintain a `CODEOWNERS_USERNAMES` file in the repository root, containing mappings from the `CODEOWNERS` email addresses to GitLab usernames.
+For this, specify `--gitlab` instead of `--keyring`, and either maintain a `CODEOWNERS_USERNAMES` file containing mappings from the `CODEOWNERS` email addresses to GitLab usernames in the repository root, or provide a GitLab API token authorized to lookup users with their email address as `GITLAB_TOKEN` in the environment.
 
 ### Example `CODEOWNERS`
 

--- a/pistis_test.go
+++ b/pistis_test.go
@@ -21,7 +21,8 @@ func TestGetCodeOwnerFingerprints(t *testing.T) {
 }
 
 func TestGetCodeOwnerUsernames(t *testing.T) {
-	result := getCodeOwnerUsernames("test_fixtures/CODEOWNERS_USERNAMES")
+	result, err := getCodeOwnerUsernames("test_fixtures/CODEOWNERS_USERNAMES")
+	assert.Nil(t, err)
 
 	assert.NotNil(t, result)
 

--- a/utils.go
+++ b/utils.go
@@ -53,6 +53,14 @@ func Info(format string, args ...any) {
 	logger.Info(fmt.Sprintf(format, args...))
 }
 
+func handleInternalError(action string, err error) error {
+	if err != nil {
+		Debug("%s failed: %s", action, err)
+	}
+
+	return err
+}
+
 func handleError(action string, err error) {
 	if err != nil {
 		Error("%s failed: %s", action, err)


### PR DESCRIPTION
To reduce the need for redundantly stored information in order to use Pistis, optionally read the usernames, which are used to fetch public PGP keys from GitLab, from GitLab as well.
As GitLab allows querying of user data based on email addresses only for authorized users, the new functionality is only enabled if a respective API token is found under "GITLAB_TOKEN" in the environment. Users in the existing CODEOWNERS_USERNAME file will still be considered.