### PR TITLE
Correct owner check

### DIFF
--- a/pistis.go
+++ b/pistis.go
@@ -270,15 +270,16 @@ func logic() {
 			for _, file := range changedFiles {
 				Info(file)
 				owners := co.Owners(file)
+				foundValidOwner := false
 				for i, owner := range owners {
 					ownerFp, haveOwnerFp := coFpMap[owner]
-					foundValidOwner := false
 					if haveOwnerFp {
 						Info("Owner #%d is %s with fingerprint %s", i, owner, ownerFp)
 						Info("Commit is signed by fingerprint %s", cFp)
 						if cFp == ownerFp {
 							Info("Matches")
 							foundValidOwner = true
+							break
 						}
 
 					} else {
@@ -286,10 +287,11 @@ func logic() {
 						Error("Owner #%d is %s with no fingerprint", i, owner)
 						os.Exit(1)
 					}
-					if !foundValidOwner {
-						Error("File is covered by CODEOWNERS, but commit modifying it was not signed by a valid owner.")
-						os.Exit(1)
-					}
+				}
+
+				if len(owners) > 0 && !foundValidOwner {
+					Error("File is covered by CODEOWNERS, but commit modifying it was not signed by a valid owner.")
+					os.Exit(1)
 				}
 			}
 		}


### PR DESCRIPTION
Changes to files covered by CODEOWNERS must be signed by one of the
respective owners. The check would instead try to match all possible
owners, which would always fail, as commits are by nature only signed
by a single person. Correct this by moving the variable outside of the
owner iteration, and improve efficiency by stopping the owner iteration
once one match is found.